### PR TITLE
Remove stray editor hint from upgradeWorldBook

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -129,9 +129,6 @@ const Utils = {
                 variables: true,
                 value: rule.value || 1,
                 comment: rule.description || ''
-Use Control + Shift + m to toggle the tab key moving focus. Alternatively, use esc then tab to move to the next interactive element on the page.
-New File at js · 508862940/yoyo 
-
             };
         });
     }


### PR DESCRIPTION
## Summary
- clean up stray editor shortcut hints from `upgradeWorldBook`

## Testing
- `node --check js/utils.js`
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bafac660e4832f86ddeb23aee7615d