### PR TITLE
refactor: guard world book triggers

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -116,11 +116,11 @@ const Utils = {
     upgradeWorldBook(oldBook) {
         return oldBook.map(rule => {
             if (rule.triggers) return rule; // 已经是新格式
-            return {
+            const triggers = rule.key ? [rule.key] : [];
+            const newRule = {
                 id: rule.id,
                 name: rule.key || '未命名规则',
                 category: rule.category || '通用',
-                triggers: [rule.key || ''],
                 content: String(rule.value || rule.description || ''),
                 enabled: true,
                 constant: false,
@@ -130,6 +130,8 @@ const Utils = {
                 value: rule.value || 1,
                 comment: rule.description || ''
             };
+            if (triggers.length) newRule.triggers = triggers;
+            return newRule;
         });
     }
 };


### PR DESCRIPTION
## Summary
- only include world book rule triggers when a key exists
- skip emitting triggers arrays when no trigger key

## Testing
- `node --check js/utils.js`
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/yoyo/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bb146dbecc832f9224980a54131c45