### PR TITLE
Add touch event support for AI thought toggles

### DIFF
--- a/js/screens/chat.js
+++ b/js/screens/chat.js
@@ -57,11 +57,17 @@ const ChatScreen = {
                     contentDiv.textContent = msg.thoughtText;
                     contentDiv.style.display = 'none'; // 默认隐藏
 
-                    summarySpan.onclick = () => {
+                    const toggleThought = () => {
                         const isOpen = detailsDiv.classList.toggle('open');
                         contentDiv.style.display = isOpen ? 'block' : 'none';
                         summarySpan.setAttribute('aria-expanded', isOpen);
                     };
+
+                    summarySpan.onclick = toggleThought;
+                    summarySpan.addEventListener('touchstart', (e) => {
+                        e.preventDefault();
+                        toggleThought();
+                    });
                     
                     detailsDiv.appendChild(summarySpan);
                     detailsDiv.appendChild(contentDiv);

--- a/style.css
+++ b/style.css
@@ -252,3 +252,13 @@ body, html { margin: 0; padding: 0; height: 100%; font-family: -apple-system, Bl
 #wallet-refresh-btn:active {
     transform: rotate(180deg) scale(0.9);
 }
+
+/* Thought details styles */
+.thought-summary {
+    cursor: pointer;
+    display: inline-block;
+}
+
+.thought-details.open .thought-content {
+    display: block;
+}


### PR DESCRIPTION
## Summary
- Allow thought summaries to toggle on touch devices by adding `touchstart` listener while keeping existing click behavior
- Style thought summary elements as interactive and show content when open

## Testing
- `node tests/upgradeWorldBook.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbb8864900832faf207c4b3d7849c9