### PR TITLE
refactor: clarify chain-of-thought settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -154,11 +154,11 @@
                 </div>
                  <hr class="separator">
                 <div class="form-group" style="display: flex; justify-content: space-between; align-items: center;">
-                    <label for="chain-of-thought-switch" style="margin-bottom: 0;">启用思维链 (总开关)</label>
+                    <label for="chain-of-thought-switch" style="margin-bottom: 0;">启用思维链（让AI后台思考）</label>
                     <input type="checkbox" id="chain-of-thought-switch" style="width: auto; height: 20px;">
                 </div>
                 <div class="form-group" style="display: flex; justify-content: space-between; align-items: center; margin-top: -10px; padding-left: 20px;">
-                    <label for="show-thought-alert-switch" style="margin-bottom: 0; font-size: 13px; color: #666;">弹窗显示思维链</label>
+                    <label for="show-thought-alert-switch" style="margin-bottom: 0; font-size: 13px; color: #666;">显示思维过程（弹窗+对话框）</label>
                     <input type="checkbox" id="show-thought-alert-switch" style="width: auto; height: 18px;">
                 </div>
                 <button id="save-general-settings-btn" class="form-button">保存通用设置</button>

--- a/js/ai.js
+++ b/js/ai.js
@@ -67,7 +67,11 @@ const AI = {
                 rawResponseText = data.choices[0]?.message?.content || '';
             }
             
-            // 处理思维链 - 增强版
+            // 处理思维链
+            let thoughtText = null;
+            let cleanedResponse = rawResponseText;
+
+            // 只有启用思维链时才解析
             if (activeChat.settings.enableChainOfThought) {
                 // 尝试匹配多种可能的思维链格式
                 const thoughtPatterns = [
@@ -76,9 +80,6 @@ const AI = {
                     /\[思考\]([\s\S]*?)\[\/思考\]/,
                     /\*thinking\*([\s\S]*?)\*\/thinking\*/i
                 ];
-
-                let thoughtText = null;
-                let cleanedResponse = rawResponseText;
 
                 for (const pattern of thoughtPatterns) {
                     const match = rawResponseText.match(pattern);
@@ -95,18 +96,21 @@ const AI = {
                     console.log(thoughtText);
                     console.groupEnd();
 
-                    // 如果开启了弹窗显示
+                    // 只有开启显示时才返回思维链并弹窗
                     if (activeChat.settings.showThoughtAsAlert) {
-                        // 创建更好看的弹窗
                         const thoughtAlert = `🤔 AI思维链分析\n━━━━━━━━━━━━━━━━━━\n${thoughtText}\n━━━━━━━━━━━━━━━━━━\n点击确定继续`;
                         alert(thoughtAlert);
+
+                        // 返回包含思维链的对象（在对话框显示折叠内容）
+                        return { text: cleanedResponse, thought: thoughtText };
                     }
 
-                    // 返回包含思维链的对象
-                    return { text: cleanedResponse, thought: thoughtText };
+                    // 只启用思维链但不显示，返回纯文本
+                    return cleanedResponse;
                 }
             }
 
+            // 未启用思维链或未找到思维链标签
             return rawResponseText.trim();
             
         } catch (error) {

--- a/js/screens/general-settings.js
+++ b/js/screens/general-settings.js
@@ -23,7 +23,7 @@ const GeneralSettingsScreen = {
             chainOfThoughtSwitch.checked = activeChat.settings.enableChainOfThought;
         }
         
-        // 弹窗显示思维链开关
+        // 显示思维过程开关（弹窗 + 对话框）
         const showThoughtAlertSwitch = document.getElementById('show-thought-alert-switch');
         if (showThoughtAlertSwitch) {
             showThoughtAlertSwitch.checked = activeChat.settings.showThoughtAsAlert;


### PR DESCRIPTION
## Summary
- Clarify chain-of-thought option labels in settings
- Revise AI chain-of-thought handling to hide thoughts unless explicitly shown

## Testing
- `node tests/upgradeWorldBook.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbc7c801f0832f9bbad8a09f6c0c68