### PR TITLE
Handle nested state paths

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -18,6 +18,7 @@ const StateManager = {
         const keys = path.split('.');
         let current = worldState;
         for (let i = 0; i < keys.length - 1; i++) {
+            if (current[keys[i]] === undefined) current[keys[i]] = {};
             current = current[keys[i]];
         }
         current[keys[keys.length - 1]] = value;

--- a/tests/stateUpdate.test.js
+++ b/tests/stateUpdate.test.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+const path = require('path');
+
+const code = fs.readFileSync(path.join(__dirname, '..', 'js', 'state.js'), 'utf8');
+const context = { window: {}, console };
+vm.createContext(context);
+const StateManager = new vm.Script(code + '\nStateManager').runInContext(context);
+
+StateManager.set({});
+StateManager.update('player.stats.score', 100);
+const state = StateManager.get();
+
+assert.strictEqual(state.player.stats.score, 100);
+console.log('update creates nested objects:', JSON.stringify(state));
+


### PR DESCRIPTION
## Summary
- Enhance `StateManager.update` to build missing nested objects before assignment
- Add test verifying state updates create nested structures

## Testing
- `node tests/upgradeWorldBook.test.js`
- `node tests/stateUpdate.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbd5e834b8832f81ce7acde4a67751