### PR TITLE
fix: handle missing model list element

### DIFF
--- a/js/screens/settings.js
+++ b/js/screens/settings.js
@@ -131,6 +131,11 @@ const SettingsScreen = {
             
             const data = await response.json();
             const apiModelsList = document.getElementById('api-models-list');
+            if (!apiModelsList) {
+                indicator.textContent = '❌ 找不到模型列表元素';
+                indicator.className = 'error';
+                return;
+            }
             apiModelsList.innerHTML = '';
             
             const models = provider === 'gemini' ? data.models : data.data;


### PR DESCRIPTION
## Summary
- add missing api models list check in fetchModels to show error if element missing

## Testing
- `node tests/upgradeWorldBook.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbd5df72a4832fbcabcfcbc39d0e7d