### PR TITLE
Handle missing aiPersona in chat title

### DIFF
--- a/js/screens/chat.js
+++ b/js/screens/chat.js
@@ -13,8 +13,10 @@ const ChatScreen = {
             return;
         }
         
-        const aiNameInTitle = activeChat.settings.aiPersona.split('。')[0]
-            .replace("你是AI伴侣'", "").replace("'", "") || state.ai?.name || '零';
+        const persona = activeChat.settings.aiPersona || state.ai?.name || '零';
+        const aiNameInTitle = persona.split('。')[0]
+            .replace("你是AI伴侣'", "")
+            .replace("'", "");
         
         const chatHeaderTitle = document.getElementById('chat-header-title');
         if (chatHeaderTitle) chatHeaderTitle.textContent = `与 ${aiNameInTitle} 的聊天`;


### PR DESCRIPTION
## Summary
- Ensure chat title computation falls back to AI name or default when `aiPersona` is absent

## Testing
- `node tests/upgradeWorldBook.test.js`
- `node -e "..."` (ChatScreen render test)


------
https://chatgpt.com/codex/tasks/task_e_68bbd5d3f45c832f84c04f23c5242d1d