### PR TITLE
fix: sanitize chain-of-thought settings

### DIFF
--- a/js/database.js
+++ b/js/database.js
@@ -165,6 +165,20 @@ const Database = {
                 }
             };
         }
+
+        // 校验并补齐聊天设置字段
+        for (const chatId in newState.chats) {
+            const settings = newState.chats[chatId].settings || {};
+            if (typeof settings.enableChainOfThought !== 'boolean') {
+                settings.enableChainOfThought = false;
+            }
+            if (settings.enableChainOfThought) {
+                settings.showThoughtAsAlert = !!settings.showThoughtAsAlert;
+            } else {
+                settings.showThoughtAsAlert = false;
+            }
+            newState.chats[chatId].settings = settings;
+        }
         
         // 计算离线收入
         const timePassedMs = Date.now() - newState.lastOnlineTimestamp;

--- a/js/screens/general-settings.js
+++ b/js/screens/general-settings.js
@@ -90,9 +90,13 @@ const GeneralSettingsScreen = {
             // 保存思维链设置
             const chainOfThoughtSwitch = document.getElementById('chain-of-thought-switch');
             activeChat.settings.enableChainOfThought = chainOfThoughtSwitch.checked;
-            
+
             const showThoughtAlertSwitch = document.getElementById('show-thought-alert-switch');
-            activeChat.settings.showThoughtAsAlert = showThoughtAlertSwitch.checked;
+            if (chainOfThoughtSwitch.checked) {
+                activeChat.settings.showThoughtAsAlert = showThoughtAlertSwitch.checked;
+            } else {
+                activeChat.settings.showThoughtAsAlert = false;
+            }
             
             // 保存世界书关联
             const selectedBookIds = [];

--- a/js/screens/settings.js
+++ b/js/screens/settings.js
@@ -279,9 +279,18 @@ const SettingsScreen = {
             if (importedData.chats) {
                 for (const chatId in importedData.chats) {
                     if (importedData.chats[chatId].settings) {
+                        const settings = importedData.chats[chatId].settings;
+                        if (typeof settings.enableChainOfThought !== 'boolean') {
+                            settings.enableChainOfThought = false;
+                        }
+                        if (settings.enableChainOfThought) {
+                            settings.showThoughtAsAlert = !!settings.showThoughtAsAlert;
+                        } else {
+                            settings.showThoughtAsAlert = false;
+                        }
                         await db.chatSettings.put({
                             id: chatId,
-                            settings: importedData.chats[chatId].settings
+                            settings
                         });
                     }
                 }


### PR DESCRIPTION
## Summary
- save chain-of-thought alert flag only when the chain-of-thought switch is enabled
- normalize chat settings on load to ensure missing chain-of-thought fields are added
- validate imported chat settings and clear inconsistent chain-of-thought flags

## Testing
- `node tests/stateUpdate.test.js`
- `node tests/upgradeWorldBook.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbdb6ac270832fb9b0a3842e99ef48