### PR TITLE
feat: upgrade chat history format

### DIFF
--- a/js/database.js
+++ b/js/database.js
@@ -76,7 +76,7 @@ const Database = {
     async loadWorldState() {
         await this.migrateFromLocalStorage();
         
-        const [general, player, ai, chatHistory, worldBook, events, apiConfig, chatSettings] = 
+        const [general, player, ai, chatHistory, worldBook, events, apiConfig, chatSettings] =
             await Promise.all([
                 this.db.general.get('main'),
                 this.db.player.get('main'),
@@ -92,7 +92,8 @@ const Database = {
         newState.lastOnlineTimestamp = general ? general.lastOnlineTimestamp : Date.now();
         newState.player = player || CONFIG.defaults.player;
         newState.ai = ai || CONFIG.defaults.ai;
-        newState.chat = { history: chatHistory || [] };
+        const upgradedHistory = Utils.upgradeChatHistory(chatHistory || []);
+        newState.chat = { history: upgradedHistory };
         
         // 升级世界书格式
         newState.worldBook = (worldBook && worldBook.length > 0) 

--- a/js/screens/settings.js
+++ b/js/screens/settings.js
@@ -265,7 +265,8 @@ const SettingsScreen = {
             if (importedData.player) await db.player.put({ id: 'main', ...importedData.player });
             if (importedData.ai) await db.ai.put({ id: 'main', ...importedData.ai });
             if (importedData.chat && importedData.chat.history) {
-                await db.chatHistory.bulkAdd(importedData.chat.history);
+                const upgradedHistory = Utils.upgradeChatHistory(importedData.chat.history);
+                await db.chatHistory.bulkAdd(upgradedHistory);
             }
             
             // 处理世界书格式升级

--- a/tests/upgradeChatHistory.test.js
+++ b/tests/upgradeChatHistory.test.js
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const vm = require('vm');
+const assert = require('assert');
+const path = require('path');
+
+const code = fs.readFileSync(path.join(__dirname, '..', 'js', 'utils.js'), 'utf8');
+const context = { window: {}, console };
+vm.createContext(context);
+const Utils = new vm.Script(code + '\nUtils').runInContext(context);
+
+const records = [
+  { sender: 'ai', content: '<thinking>plan</thinking>answer' },
+  { sender: 'user', content: 'hi' }
+];
+
+const upgraded = Utils.upgradeChatHistory(records);
+
+assert.strictEqual(upgraded[0].content.length, 1);
+assert.strictEqual(upgraded[0].content[0].text, 'answer');
+assert.strictEqual(upgraded[0].thoughtText, 'plan');
+assert.strictEqual(upgraded[1].content.length, 1);
+assert.strictEqual(upgraded[1].content[0].text, 'hi');
+assert.strictEqual(upgraded[1].thoughtText, '');
+
+console.log('upgradeChatHistory:', JSON.stringify(upgraded));


### PR DESCRIPTION
## Summary
- parse <thought>/<thinking> tags into a separate `thoughtText` via `Utils.upgradeChatHistory`
- upgrade stored chat histories in `Database.loadWorldState` and `Settings.importData`
- add tests for chat history upgrading

## Testing
- `node tests/stateUpdate.test.js && node tests/upgradeWorldBook.test.js && node tests/upgradeChatHistory.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbdb7241a0832fb549a833afd018b4