### PR TITLE
feat: add chain of thought defaults to chat settings

### DIFF
--- a/js/database.js
+++ b/js/database.js
@@ -150,7 +150,17 @@ const Database = {
         newState.chats = {};
         if (chatSettings && chatSettings.length > 0) {
             chatSettings.forEach(cs => {
-                newState.chats[cs.id] = { settings: cs.settings };
+                const settings = cs.settings || {};
+                if (typeof settings.enableChainOfThought !== 'boolean') {
+                    settings.enableChainOfThought = false;
+                }
+                if (typeof settings.showThoughtAsAlert !== 'boolean') {
+                    settings.showThoughtAsAlert = false;
+                }
+                if (!settings.enableChainOfThought && settings.showThoughtAsAlert) {
+                    settings.showThoughtAsAlert = false;
+                }
+                newState.chats[cs.id] = { settings };
             });
         }
         

--- a/js/screens/settings.js
+++ b/js/screens/settings.js
@@ -279,9 +279,19 @@ const SettingsScreen = {
             if (importedData.chats) {
                 for (const chatId in importedData.chats) {
                     if (importedData.chats[chatId].settings) {
+                        const settings = importedData.chats[chatId].settings;
+                        if (typeof settings.enableChainOfThought !== 'boolean') {
+                            settings.enableChainOfThought = false;
+                        }
+                        if (typeof settings.showThoughtAsAlert !== 'boolean') {
+                            settings.showThoughtAsAlert = false;
+                        }
+                        if (!settings.enableChainOfThought && settings.showThoughtAsAlert) {
+                            settings.showThoughtAsAlert = false;
+                        }
                         await db.chatSettings.put({
                             id: chatId,
-                            settings: importedData.chats[chatId].settings
+                            settings
                         });
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure chats loaded from IndexedDB have enableChainOfThought and showThoughtAsAlert defaults
- validate chat setting imports include the new flags and auto-correct inconsistencies

## Testing
- `node tests/stateUpdate.test.js`
- `node tests/upgradeWorldBook.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbdb746818832f80b16ebf02ee9beb