### PR TITLE
fix: upgrade imported data and add manual repair

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,9 +161,10 @@
                     <label for="show-thought-alert-switch" style="margin-bottom: 0; font-size: 13px; color: #666;">显示思维过程（弹窗+对话框）</label>
                     <input type="checkbox" id="show-thought-alert-switch" style="width: auto; height: 18px;">
                 </div>
-                <button id="save-general-settings-btn" class="form-button">保存通用设置</button>
-            </div>
-        </section>
+                  <button id="save-general-settings-btn" class="form-button">保存通用设置</button>
+                  <button id="fix-data-btn" class="form-button-secondary" style="margin-top: 10px;">修复数据兼容性</button>
+              </div>
+          </section>
                 <section id="lock-screen" class="screen">
             <div class="time-display">10:24</div>
             <div class="unlock-prompt">点击屏幕以解锁</div>

--- a/js/main.js
+++ b/js/main.js
@@ -360,9 +360,23 @@ document.addEventListener('DOMContentLoaded', () => {
         Utils.safeBind(document.getElementById('save-general-settings-btn'), 'click', () => {
             GeneralSettingsScreen.save();
         });
-        
+
         Utils.safeBind(document.getElementById('chain-of-thought-switch'), 'change', () => {
             GeneralSettingsScreen.toggleChainOfThought();
+        });
+
+        Utils.safeBind(document.getElementById('fix-data-btn'), 'click', async () => {
+            const state = StateManager.get();
+            state.chat.history = Utils.upgradeChatHistory(state.chat.history);
+            const settings = state.chats['chat_default'].settings;
+            settings.enableChainOfThought ??= false;
+            settings.showThoughtAsAlert ??= false;
+            if (!settings.enableChainOfThought) {
+                settings.showThoughtAsAlert = false;
+            }
+            await Database.saveWorldState();
+            GeneralSettingsScreen.render();
+            alert('数据修复完成！');
         });
     }
     

--- a/js/screens/settings.js
+++ b/js/screens/settings.js
@@ -279,24 +279,15 @@ const SettingsScreen = {
             if (importedData.apiConfig) await db.apiConfig.put({ id: 'main', ...importedData.apiConfig });
             if (importedData.chats) {
                 for (const chatId in importedData.chats) {
-if (importedData.chats) {
-    for (const chatId in importedData.chats) {
-        const settings = importedData.chats[chatId].settings || {};
-        settings.enableChainOfThought ??= false;
-        settings.showThoughtAsAlert ??= false;
-        if (!settings.enableChainOfThought) {
-            settings.showThoughtAsAlert = false;
-        }
-        await db.chatSettings.put({
-            id: chatId,
-            settings,
-        });
-    }
-}
-
+                    const settings = importedData.chats[chatId].settings || {};
+                    settings.enableChainOfThought ??= false;
+                    settings.showThoughtAsAlert ??= false;
+                    if (!settings.enableChainOfThought) {
+                        settings.showThoughtAsAlert = false;
+                    }
                     await db.chatSettings.put({
                         id: chatId,
-                        settings,
+                        settings
                     });
                 }
             }


### PR DESCRIPTION
## Summary
- upgrade imported chat history and sanitize missing thought settings
- ensure importData fills new chat settings fields
- add manual "数据修复" button to re-upgrade history and settings

## Testing
- `node tests/stateUpdate.test.js`
- `node tests/upgradeChatHistory.test.js`
- `node tests/upgradeWorldBook.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68bbead77d8c832fb69e983b7355740e