### PR TITLE
feat: overhaul world book management

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,270 @@
         </section>
         <section id="store-screen" class="screen"> <header class="store-header"><button id="store-back-btn" class="back-btn">‹</button><h2>商店</h2></header> <div class="store-content"><p>你的余额: <span id="store-player-money-display">0</span> 金币</p><div id="item-list" class="item-list"></div></div> </section>
         <section id="backpack-screen" class="screen"> <header class="backpack-header"><button id="backpack-back-btn" class="back-btn">‹</button><h2>我的背包</h2></header> <div id="inventory-list" class="inventory-list"></div> </section>
-        <section id="world-book-screen" class="screen"> <header class="world-book-header"><button id="world-book-back-btn" class="back-btn">‹</button><h2>世界书</h2></header> <div id="rule-list" class="rule-list"></div> </section>
+        <section id="world-book-screen" class="screen">
+            <header class="world-book-header">
+                <button id="world-book-back-btn" class="back-btn">‹</button>
+                <h2 id="wb-screen-title">世界书</h2>
+                <div class="wb-header-actions">
+                    <button id="wb-sandbox-btn" class="wb-icon-btn" title="测试沙盒">🧪</button>
+                    <button id="wb-settings-btn" class="wb-icon-btn" title="激活设置">⚙️</button>
+                </div>
+            </header>
+
+            <!-- 书架视图（主页） -->
+            <div id="wb-shelf-view" class="wb-view">
+                <div class="wb-toolbar">
+                    <button class="wb-btn-primary" onclick="WorldBookScreen.createBook()">➕ 新建世界书</button>
+                    <button class="wb-btn" onclick="WorldBookScreen.exportAll()">📤 导出全部</button>
+                    <button class="wb-btn" onclick="WorldBookScreen.importAll()">📥 导入</button>
+                </div>
+                <div id="wb-books-grid" class="wb-books-grid"></div>
+            </div>
+
+            <!-- 书本详情视图 -->
+            <div id="wb-book-view" class="wb-view" style="display:none;">
+                <div class="wb-book-header">
+                    <button class="wb-btn" onclick="WorldBookScreen.backToShelf()">← 返回书架</button>
+                    <h3 id="wb-current-book-name">书名</h3>
+                    <span id="wb-current-book-info" class="wb-book-meta"></span>
+                </div>
+
+                <div class="wb-toolbar">
+                    <input type="text" id="wb-entry-search" class="wb-search" placeholder="搜索条目...">
+                    <select id="wb-entry-sort" class="wb-select">
+                        <option value="order-desc">按优先级↓</option>
+                        <option value="order-asc">按优先级↑</option>
+                        <option value="title">按标题</option>
+                        <option value="updated">按更新时间</option>
+                    </select>
+                    <button class="wb-btn-primary" onclick="WorldBookScreen.createEntry()">➕ 新条目</button>
+                    <button class="wb-btn" onclick="WorldBookScreen.exportBook()">📤 导出本书</button>
+                    <button class="wb-btn" onclick="WorldBookScreen.importToBook()">📥 导入到本书</button>
+                </div>
+
+                <div class="wb-entries-table">
+                    <table>
+                        <thead>
+                            <tr>
+                                <th>ID/标题</th>
+                                <th>优先级</th>
+                                <th>位置</th>
+                                <th>策略</th>
+                                <th>触发词</th>
+                                <th>操作</th>
+                            </tr>
+                        </thead>
+                        <tbody id="wb-entries-tbody"></tbody>
+                    </table>
+                </div>
+            </div>
+
+            <!-- 激活设置视图 -->
+            <div id="wb-settings-view" class="wb-view" style="display:none;">
+                <div class="wb-settings-header">
+                    <button class="wb-btn" onclick="WorldBookScreen.backToShelf()">← 返回</button>
+                    <h3>激活设置</h3>
+                </div>
+
+                <div class="wb-settings-content">
+                    <div class="wb-setting-group">
+                        <label>扫描深度 (ScanDepth)</label>
+                        <input type="number" id="wb-scan-depth" min="0" max="50" value="8">
+                        <span class="wb-hint">回溯多少条消息进行关键词扫描</span>
+                    </div>
+
+                    <div class="wb-setting-group">
+                        <label>最小激活数 (MinActivations)</label>
+                        <input type="number" id="wb-min-activations" min="0" max="20" value="0">
+                        <span class="wb-hint">至少激活几条世界书条目</span>
+                    </div>
+
+                    <div class="wb-setting-group">
+                        <label>最大递归深度 (MaxRecursion)</label>
+                        <input type="number" id="wb-max-recursion" min="1" max="10" value="3">
+                        <span class="wb-hint">条目间相互触发的最大层数</span>
+                    </div>
+
+                    <div class="wb-setting-group">
+                        <label>上下文预算 (%)</label>
+                        <input type="range" id="wb-budget-percent" min="5" max="50" value="15">
+                        <span id="wb-budget-display">15%</span>
+                        <span class="wb-hint">分配给世界书的上下文比例</span>
+                    </div>
+
+                    <div class="wb-setting-group">
+                        <label><input type="checkbox" id="wb-include-names" checked> 包含说话者名字</label>
+                        <label><input type="checkbox" id="wb-case-sensitive"> 区分大小写</label>
+                        <label><input type="checkbox" id="wb-whole-words" checked> 整词匹配</label>
+                        <label><input type="checkbox" id="wb-overflow-alert" checked> 溢出警告</label>
+                    </div>
+
+                    <button class="wb-btn-primary" onclick="WorldBookScreen.saveSettingsToStorage()">保存设置</button>
+                </div>
+            </div>
+
+            <!-- 测试沙盒视图 -->
+            <div id="wb-sandbox-view" class="wb-view" style="display:none;">
+                <div class="wb-sandbox-header">
+                    <button class="wb-btn" onclick="WorldBookScreen.backToShelf()">← 返回</button>
+                    <h3>测试沙盒</h3>
+                </div>
+
+                <div class="wb-sandbox-content">
+                    <div class="wb-sandbox-input">
+                        <label>最近上下文</label>
+                        <textarea id="wb-test-context" placeholder="输入最近的对话内容..."></textarea>
+
+                        <label>本轮输入</label>
+                        <input type="text" id="wb-test-input" placeholder="输入要测试的文本...">
+
+                        <button class="wb-btn-primary" onclick="WorldBookScreen.runTest()">运行测试</button>
+                    </div>
+
+                    <div class="wb-sandbox-results">
+                        <div class="wb-result-section">
+                            <h4>✅ 已注入</h4>
+                            <div id="wb-injected-list"></div>
+                        </div>
+
+                        <div class="wb-result-section">
+                            <h4>⏳ 延迟激活</h4>
+                            <div id="wb-delayed-list"></div>
+                        </div>
+
+                        <div class="wb-result-section">
+                            <h4>🧊 冷却中</h4>
+                            <div id="wb-cooldown-list"></div>
+                        </div>
+
+                        <div class="wb-result-section">
+                            <h4>✂️ 被裁剪</h4>
+                            <div id="wb-truncated-list"></div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- 条目编辑抽屉 -->
+        <div id="wb-entry-drawer" class="wb-drawer">
+            <div class="wb-drawer-overlay" onclick="WorldBookScreen.closeDrawer()"></div>
+            <div class="wb-drawer-content">
+                <div class="wb-drawer-header">
+                    <h3>编辑条目</h3>
+                    <button class="wb-close-btn" onclick="WorldBookScreen.closeDrawer()">×</button>
+                </div>
+
+                <div class="wb-drawer-body">
+                    <div class="wb-form-group">
+                        <label>ID *</label>
+                        <input type="text" id="wb-entry-id" placeholder="例如: wb.core.lighthouse">
+                    </div>
+
+                    <div class="wb-form-group">
+                        <label>标题</label>
+                        <input type="text" id="wb-entry-title" placeholder="条目标题（仅显示用）">
+                    </div>
+
+                    <div class="wb-form-row">
+                        <div class="wb-form-group">
+                            <label>作用域</label>
+                            <select id="wb-entry-scope">
+                                <option value="global">全局</option>
+                                <option value="char">角色</option>
+                                <option value="event">事件</option>
+                            </select>
+                        </div>
+
+                        <div class="wb-form-group">
+                            <label>说话者</label>
+                            <select id="wb-entry-speaker">
+                                <option value="any">任意</option>
+                                <option value="fang">方亦楷</option>
+                                <option value="gu">顾烬寒</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="wb-form-group">
+                        <label>触发词（逗号分隔，支持正则）</label>
+                        <input type="text" id="wb-entry-keys" placeholder="玻璃, /\bPain Echo\b/i">
+                    </div>
+
+                    <div class="wb-form-group">
+                        <label>可选过滤器</label>
+                        <input type="text" id="wb-entry-filters" placeholder="AND ANY: 梦境, 回响">
+                    </div>
+
+                    <div class="wb-form-group">
+                        <label>内容 *</label>
+                        <textarea id="wb-entry-content" rows="4" placeholder="实际注入的文本内容..."></textarea>
+                    </div>
+
+                    <div class="wb-form-row">
+                        <div class="wb-form-group">
+                            <label>优先级</label>
+                            <input type="number" id="wb-entry-order" value="60" min="0" max="999">
+                        </div>
+
+                        <div class="wb-form-group">
+                            <label>位置</label>
+                            <select id="wb-entry-position">
+                                <option value="after_char_defs">角色定义后</option>
+                                <option value="before_char_defs">角色定义前</option>
+                                <option value="an_top">作者注顶部</option>
+                                <option value="an_bottom">作者注底部</option>
+                                <option value="depth0_system">@Depth=0 (系统)</option>
+                            </select>
+                        </div>
+                    </div>
+
+                    <div class="wb-form-group">
+                        <label>策略</label>
+                        <select id="wb-entry-strategy">
+                            <option value="trigger">触发式</option>
+                            <option value="always">常驻</option>
+                            <option value="vector" disabled>向量召回（未来）</option>
+                        </select>
+                    </div>
+
+                    <div class="wb-form-group">
+                        <label>时序控制</label>
+                        <div class="wb-timing-row">
+                            <input type="number" id="wb-entry-delay" min="0" placeholder="延迟">
+                            <input type="number" id="wb-entry-sticky" min="0" placeholder="黏着">
+                            <input type="number" id="wb-entry-cooldown" min="0" placeholder="冷却">
+                        </div>
+                    </div>
+
+                    <div class="wb-form-group">
+                        <label>
+                            <input type="checkbox" id="wb-entry-recursion" checked> 允许递归
+                        </label>
+                        <input type="number" id="wb-entry-max-steps" min="1" max="10" value="2" placeholder="最大递归层数">
+                    </div>
+
+                    <div class="wb-form-group">
+                        <label>标签（逗号分隔）</label>
+                        <input type="text" id="wb-entry-tags" placeholder="scope:global, tone:warm">
+                    </div>
+
+                    <div class="wb-form-group">
+                        <label>
+                            <input type="checkbox" id="wb-entry-enabled" checked> 启用此条目
+                        </label>
+                    </div>
+
+                    <div class="wb-drawer-footer">
+                        <button class="wb-btn-primary" onclick="WorldBookScreen.saveEntry()">保存</button>
+                        <button class="wb-btn" onclick="WorldBookScreen.deleteEntry()">删除</button>
+                        <button class="wb-btn" onclick="WorldBookScreen.closeDrawer()">取消</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <input type="file" id="wb-import-file" accept=".json" style="display:none;">
         
         <section id="settings-screen" class="screen">
             <header class="settings-header">

--- a/js/main.js
+++ b/js/main.js
@@ -249,50 +249,23 @@ document.addEventListener('DOMContentLoaded', () => {
         // 世界书应用
         Utils.safeBind(document.getElementById('open-world-book-app'), 'click', () => {
             Utils.showScreen('world-book-screen');
+            WorldBookScreen.init();
             WorldBookScreen.render();
         });
-        
+
         Utils.safeBind(document.getElementById('world-book-back-btn'), 'click', () => {
             Utils.showScreen('home-screen');
         });
-        
-        Utils.safeBind(document.getElementById('rule-list'), 'click', async (event) => {
-            const target = event.target;
-            
-            // 编辑按钮
-            if (target.classList.contains('wb-edit-btn') || target.dataset.ruleId) {
-                const ruleId = target.dataset.ruleId;
-                if (ruleId) {
-                    WorldBookScreen.render(ruleId);
-                    return;
-                }
-            }
-            
-            // 保存按钮
-            if (target.classList.contains('wb-save-btn')) {
-                const ruleId = target.dataset.ruleId;
-                if (ruleId) {
-                    await WorldBookScreen.saveEntry(ruleId);
-                }
-            }
-            
-            // 取消按钮
-            if (target.classList.contains('wb-cancel-btn')) {
-                const ruleId = target.dataset.ruleId;
-                if (ruleId) {
-                    await WorldBookScreen.cancelEdit(ruleId);
-                }
-            }
-            
-            // 删除按钮
-            if (target.classList.contains('wb-delete-btn')) {
-                const ruleId = target.dataset.ruleId;
-                if (ruleId) {
-                    await WorldBookScreen.deleteEntry(ruleId);
-                }
-            }
+
+        // 世界书内部导航
+        Utils.safeBind(document.getElementById('wb-sandbox-btn'), 'click', () => {
+            WorldBookScreen.showView('sandbox');
         });
-        
+
+        Utils.safeBind(document.getElementById('wb-settings-btn'), 'click', () => {
+            WorldBookScreen.showView('settings');
+        });
+
         // API设置应用
         Utils.safeBind(document.getElementById('open-settings-app'), 'click', () => {
             Utils.showScreen('settings-screen');

--- a/js/screens/worldbook.js
+++ b/js/screens/worldbook.js
@@ -1,336 +1,926 @@
-// 世界书界面模块
+// 世界书增强模块
 const WorldBookScreen = {
-    render(editingRuleId = null) {
-        const state = StateManager.get();
-        const ruleListContainer = document.getElementById('rule-list');
-        if (!ruleListContainer) return;
-        
-        ruleListContainer.innerHTML = '';
-        
-        // 工具栏
-        const toolbar = document.createElement('div');
-        toolbar.className = 'world-book-toolbar';
-        
-        const addBtn = document.createElement('button');
-        addBtn.className = 'form-button';
-        addBtn.textContent = '➕ 新建条目';
-        addBtn.onclick = () => {
-            const newRule = {
-                id: `rule_${Date.now()}`,
-                name: '新条目',
-                category: '通用',
-                triggers: [],
-                content: '',
-                enabled: true,
-                constant: false,
-                position: 'after',
-                priority: 100,
-                variables: true,
-                comment: '',
-                isNew: true
-            };
-            state.worldBook.push(newRule);
-            this.render(newRule.id);
-        };
-        
-        const exportBtn = document.createElement('button');
-        exportBtn.className = 'form-button-secondary';
-        exportBtn.textContent = '📤 导出';
-        exportBtn.onclick = () => {
-            const dataStr = JSON.stringify(state.worldBook, null, 2);
-            const blob = new Blob([dataStr], {type: 'application/json'});
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = `世界书_${new Date().toLocaleDateString().replace(/\//g, '-')}.json`;
-            a.click();
-            URL.revokeObjectURL(url);
-        };
-        
-        const importBtn = document.createElement('button');
-        importBtn.className = 'form-button-secondary';
-        importBtn.textContent = '📥 导入';
-        importBtn.onclick = () => {
-            const input = document.createElement('input');
-            input.type = 'file';
-            input.accept = '.json';
-            input.onchange = async (e) => {
-                const file = e.target.files[0];
-                if (!file) return;
-                try {
-                    const text = await file.text();
-                    const rules = JSON.parse(text);
-                    if (Array.isArray(rules)) {
-                        if (confirm('要替换现有规则还是追加？\n确定=替换，取消=追加')) {
-                            state.worldBook = rules;
-                        } else {
-                            state.worldBook.push(...rules);
-                        }
-                        await Database.saveWorldState();
-                        this.render();
-                        alert('导入成功！');
-                    }
-                } catch (err) {
-                    alert('导入失败：' + err.message);
+    // 数据存储键
+    BOOKS_KEY: 'worldbook.books',
+    ENTRIES_KEY: 'worldbook.entries',
+    SETTINGS_KEY: 'worldbook.settings',
+
+    // 当前状态
+    currentView: 'shelf',
+    currentBookId: null,
+    editingEntry: null,
+
+    // 初始化
+    init() {
+        this.ensureDefaultBooks();
+        this.loadSettings();
+        this.bindEvents();
+    },
+
+    // 确保有默认书本
+    ensureDefaultBooks() {
+        let books = this.loadBooks();
+        if (books.length === 0) {
+            books = [
+                {
+                    id: 'book.global',
+                    name: '全局世界书',
+                    scope: 'global',
+                    persona: '',
+                    desc: '全局设定、规则、口吻和氛围',
+                    entryCount: 0,
+                    createdAt: Date.now(),
+                    updatedAt: Date.now()
+                },
+                {
+                    id: 'book.char.fang',
+                    name: '方亦楷·世界书',
+                    scope: 'char',
+                    persona: 'fang',
+                    desc: '方亦楷的角色设定和专属规则',
+                    entryCount: 0,
+                    createdAt: Date.now(),
+                    updatedAt: Date.now()
+                },
+                {
+                    id: 'book.char.ai',
+                    name: `${StateManager.get().ai.name}·世界书`,
+                    scope: 'char',
+                    persona: 'ai',
+                    desc: 'AI角色的设定和规则',
+                    entryCount: 0,
+                    createdAt: Date.now(),
+                    updatedAt: Date.now()
+                },
+                {
+                    id: 'book.event',
+                    name: '事件世界书',
+                    scope: 'event',
+                    persona: '',
+                    desc: '特殊事件、场景和状态',
+                    entryCount: 0,
+                    createdAt: Date.now(),
+                    updatedAt: Date.now()
                 }
-            };
-            input.click();
-        };
-        
-        toolbar.appendChild(addBtn);
-        toolbar.appendChild(exportBtn);
-        toolbar.appendChild(importBtn);
-        ruleListContainer.appendChild(toolbar);
-        
-        // 渲染条目列表
-        state.worldBook.sort((a, b) => b.priority - a.priority).forEach(rule => {
-            const card = document.createElement('div');
-            card.className = 'world-book-entry';
-            
-            if (rule.id === editingRuleId) {
-                // 编辑模式
-                this.renderEditForm(card, rule);
-            } else {
-                // 显示模式
-                this.renderDisplayMode(card, rule);
+            ];
+            this.saveBooks(books);
+
+            // 迁移旧数据
+            this.migrateOldData();
+        }
+    },
+
+    // 迁移旧世界书数据
+    migrateOldData() {
+        const state = StateManager.get();
+        if (state.worldBook && state.worldBook.length > 0) {
+            const entries = [];
+            state.worldBook.forEach(oldRule => {
+                // 判断应该归属哪本书
+                let bookId = 'book.global';
+                let scope = 'global';
+                let speaker = 'any';
+
+                if (oldRule.category === '角色') {
+                    bookId = 'book.char.ai';
+                    scope = 'char';
+                } else if (oldRule.category === '事件') {
+                    bookId = 'book.event';
+                    scope = 'event';
+                }
+
+                const entry = {
+                    id: oldRule.id || `wb.migrated.${Date.now()}_${Math.random().toString(36).substr(2, 9)}`,
+                    bookId: bookId,
+                    title: oldRule.name || '未命名条目',
+                    scope: scope,
+                    speaker: speaker,
+                    keys: oldRule.triggers || [],
+                    filters: [],
+                    content: oldRule.content || '',
+                    order: oldRule.priority || 100,
+                    position: oldRule.position || 'after_char_defs',
+                    strategy: oldRule.constant ? 'always' : 'trigger',
+                    timing: {
+                        delay: 0,
+                        sticky: 0,
+                        cooldown: 0
+                    },
+                    recursion: {
+                        allow: true,
+                        maxSteps: 2
+                    },
+                    tags: [`迁移自旧版`, `category:${oldRule.category}`],
+                    enabled: oldRule.enabled !== false,
+                    _meta: {
+                        createdAt: Date.now(),
+                        updatedAt: Date.now()
+                    }
+                };
+
+                entries.push(entry);
+            });
+
+            if (entries.length > 0) {
+                this.saveEntries(entries);
+                this.updateBookCounts();
+                console.log(`成功迁移 ${entries.length} 个旧世界书条目`);
             }
-            
-            ruleListContainer.appendChild(card);
+        }
+    },
+
+    // 数据加载和保存
+    loadBooks() {
+        try {
+            const data = localStorage.getItem(this.BOOKS_KEY);
+            return data ? JSON.parse(data) : [];
+        } catch (e) {
+            console.error('加载世界书失败:', e);
+            return [];
+        }
+    },
+
+    saveBooks(books) {
+        localStorage.setItem(this.BOOKS_KEY, JSON.stringify(books));
+    },
+
+    loadEntries() {
+        try {
+            const data = localStorage.getItem(this.ENTRIES_KEY);
+            return data ? JSON.parse(data) : [];
+        } catch (e) {
+            console.error('加载条目失败:', e);
+            return [];
+        }
+    },
+
+    saveEntries(entries) {
+        localStorage.setItem(this.ENTRIES_KEY, JSON.stringify(entries));
+    },
+
+    loadSettings() {
+        try {
+            const data = localStorage.getItem(this.SETTINGS_KEY);
+            return data ? JSON.parse(data) : this.getDefaultSettings();
+        } catch (e) {
+            return this.getDefaultSettings();
+        }
+    },
+
+    saveSettings(settings) {
+        localStorage.setItem(this.SETTINGS_KEY, JSON.stringify(settings));
+    },
+
+    getDefaultSettings() {
+        return {
+            scanDepth: 8,
+            minActivations: 0,
+            maxRecursion: 3,
+            budgetPercent: 15,
+            includeNames: true,
+            caseSensitive: false,
+            wholeWords: true,
+            overflowAlert: true
+        };
+    },
+
+    // 界面渲染
+    render() {
+        this.showView('shelf');
+    },
+
+    showView(viewName) {
+        this.currentView = viewName;
+
+        // 隐藏所有视图
+        document.querySelectorAll('.wb-view').forEach(v => v.style.display = 'none');
+
+        // 显示指定视图
+        const viewId = `wb-${viewName}-view`;
+        const view = document.getElementById(viewId);
+        if (view) {
+            view.style.display = 'block';
+
+            // 根据视图渲染内容
+            switch(viewName) {
+                case 'shelf':
+                    this.renderShelf();
+                    document.getElementById('wb-screen-title').textContent = '世界书';
+                    break;
+                case 'book':
+                    this.renderBook();
+                    break;
+                case 'settings':
+                    this.renderSettings();
+                    document.getElementById('wb-screen-title').textContent = '激活设置';
+                    break;
+                case 'sandbox':
+                    this.renderSandbox();
+                    document.getElementById('wb-screen-title').textContent = '测试沙盒';
+                    break;
+            }
+        }
+    },
+
+    // 渲染书架
+    renderShelf() {
+        const container = document.getElementById('wb-books-grid');
+        if (!container) return;
+
+        container.innerHTML = '';
+        const books = this.loadBooks();
+
+        books.forEach(book => {
+            const card = document.createElement('div');
+            card.className = 'wb-book-card';
+            card.onclick = () => this.openBook(book.id);
+
+            const icon = this.getBookIcon(book.scope);
+
+            card.innerHTML = `
+                <div class="wb-book-icon">${icon}</div>
+                <div class="wb-book-info">
+                    <h3>${book.name}</h3>
+                    <p>${book.entryCount || 0}个条目 · ${this.getScopeLabel(book.scope)}作用域</p>
+                    <p style="font-size:12px;color:#999;">${book.desc || ''}</p>
+                </div>
+            `;
+
+            container.appendChild(card);
         });
     },
-    
-    renderEditForm(card, rule) {
-        const form = document.createElement('div');
-        form.className = 'wb-edit-form';
-        
-        // 第一行：名称和分类
-        const row1 = document.createElement('div');
-        row1.className = 'wb-edit-row';
-        row1.innerHTML = `
-            <input type="text" id="wb-name-${rule.id}" class="wb-edit-input" value="${rule.name}" placeholder="条目名称">
-            <select id="wb-category-${rule.id}" class="wb-edit-select">
-                <option value="通用">通用</option>
-                <option value="角色">角色</option>
-                <option value="场景">场景</option>
-                <option value="物品">物品</option>
-                <option value="经济">经济</option>
-                <option value="事件">事件</option>
-            </select>
-        `;
-        
-        // 触发词
-        const triggers = document.createElement('input');
-        triggers.type = 'text';
-        triggers.id = `wb-triggers-${rule.id}`;
-        triggers.className = 'wb-edit-input';
-        triggers.value = rule.triggers.join(', ');
-        triggers.placeholder = '触发词（逗号分隔）';
-        
-        // 内容
-        const content = document.createElement('textarea');
-        content.id = `wb-content-${rule.id}`;
-        content.className = 'wb-edit-textarea';
-        content.rows = 4;
-        content.placeholder = '内容（支持变量：{{player.money}} 等）';
-        content.value = rule.content;
-        
-       // 选项
-        const options = document.createElement('div');
-        options.className = 'wb-edit-checkboxes';
-        options.innerHTML = `
-            <label><input type="checkbox" id="wb-enabled-${rule.id}" ${rule.enabled ? 'checked' : ''}> 启用</label>
-            <label><input type="checkbox" id="wb-constant-${rule.id}" ${rule.constant ? 'checked' : ''}> 始终激活</label>
-            <label><input type="checkbox" id="wb-variables-${rule.id}" ${rule.variables ? 'checked' : ''}> 变量替换</label>
-            <input type="number" id="wb-priority-${rule.id}" class="wb-edit-priority" value="${rule.priority}" placeholder="优先级">
-            ${rule.id === 'rule001' ? `
-                <div style="margin-top: 10px;">
-                    <label>离线收益值: <input type="number" id="wb-value-${rule.id}" 
-                        value="${rule.value || 1}" min="0" style="width: 60px;"> 金币/分钟</label>
-                </div>
-            ` : ''}
-        `;
-        
-        // 备注
-        const comment = document.createElement('input');
-        comment.type = 'text';
-        comment.id = `wb-comment-${rule.id}`;
-        comment.className = 'wb-edit-input';
-        comment.value = rule.comment;
-        comment.placeholder = '备注（可选）';
-        
-        // 实时预览
-        const previewWrap = document.createElement('div');
-        previewWrap.className = 'wb-live-preview';
-        previewWrap.innerHTML = `
-            <div class="wb-live-title">实时预览</div>
-            <div id="wb-preview-${rule.id}" class="wb-live-body"></div>
-        `;
-        
-        // 按钮
-        const actions = document.createElement('div');
-        actions.className = 'wb-edit-actions';
 
-        const saveBtn = document.createElement('button');
-        saveBtn.type = 'button';
-        saveBtn.className = 'wb-save-btn';
-        saveBtn.textContent = '保存';
-        saveBtn.onclick = () => this.saveEntry(rule.id);
-
-        const cancelBtn = document.createElement('button');
-        cancelBtn.type = 'button';
-        cancelBtn.className = 'wb-cancel-btn';
-        cancelBtn.textContent = '取消';
-        cancelBtn.onclick = () => this.cancelEdit(rule.id);
-
-        const deleteBtn = document.createElement('button');
-        deleteBtn.type = 'button';
-        deleteBtn.className = 'wb-delete-btn';
-        deleteBtn.textContent = '删除';
-        deleteBtn.onclick = () => this.deleteEntry(rule.id);
-
-        actions.appendChild(saveBtn);
-        actions.appendChild(cancelBtn);
-        actions.appendChild(deleteBtn);
-        
-        form.appendChild(row1);
-        form.appendChild(triggers);
-        form.appendChild(content);
-        form.appendChild(options);
-        form.appendChild(previewWrap);
-        form.appendChild(comment);
-        form.appendChild(actions);
-        card.appendChild(form);
-        
-        // 设置当前值和预览
-        setTimeout(() => {
-            document.getElementById(`wb-category-${rule.id}`).value = rule.category;
-            this.updatePreview(rule.id);
-            
-            // 绑定预览更新
-            content.addEventListener('input', () => this.updatePreview(rule.id));
-            document.getElementById(`wb-variables-${rule.id}`)?.addEventListener('change', 
-                () => this.updatePreview(rule.id));
-        }, 0);
+    // 获取书本图标
+    getBookIcon(scope) {
+        const icons = {
+            'global': '🌍',
+            'char': '👤',
+            'event': '⚡'
+        };
+        return icons[scope] || '📚';
     },
-    
-    renderDisplayMode(card, rule) {
-        const header = document.createElement('div');
-        header.className = 'wb-entry-header';
-        
-        const content = document.createElement('div');
-        content.className = 'wb-entry-content';
-        
-        const title = document.createElement('div');
-        title.className = 'wb-entry-title';
-        title.innerHTML = `
-            <span class="wb-entry-name">${rule.name}</span>
-            <span class="wb-entry-category">${rule.category}</span>
-            <span>${rule.enabled ? '✅' : '❌'}</span>
-            ${rule.constant ? '<span>📌</span>' : ''}
-            <span class="wb-entry-priority">优先级: ${rule.priority}</span>
-        `;
-        
-        const triggers = document.createElement('div');
-        triggers.className = 'wb-entry-triggers';
-        const triggersText = rule.triggers.length > 0 ? rule.triggers.join(', ') : '(无触发词)';
-        triggers.innerHTML = `触发词: <code>${triggersText}</code>`;
-        
-        const text = document.createElement('div');
-        text.className = 'wb-entry-text';
-        const preview = rule.variables ? Utils.replaceVariables(rule.content) : rule.content;
-        text.textContent = preview.substring(0, 100) + (preview.length > 100 ? '...' : '');
-        
-        content.appendChild(title);
-        content.appendChild(triggers);
-        content.appendChild(text);
-        
-        if (rule.comment) {
-            const comment = document.createElement('div');
-            comment.className = 'wb-entry-comment';
-            comment.textContent = rule.comment;
-            content.appendChild(comment);
+
+    // 获取作用域标签
+    getScopeLabel(scope) {
+        const labels = {
+            'global': '全局',
+            'char': '角色',
+            'event': '事件'
+        };
+        return labels[scope] || scope;
+    },
+
+    // 打开书本
+    openBook(bookId) {
+        this.currentBookId = bookId;
+        this.showView('book');
+    },
+
+    // 渲染书本详情
+    renderBook() {
+        if (!this.currentBookId) return;
+
+        const book = this.loadBooks().find(b => b.id === this.currentBookId);
+        if (!book) return;
+
+        // 更新标题
+        document.getElementById('wb-current-book-name').textContent = book.name;
+        document.getElementById('wb-current-book-info').textContent =
+            `${this.getScopeLabel(book.scope)} · ${book.persona || '通用'}`;
+
+        // 渲染条目列表
+        this.renderEntries();
+    },
+
+    // 渲染条目列表
+    renderEntries() {
+        const tbody = document.getElementById('wb-entries-tbody');
+        if (!tbody) return;
+
+        tbody.innerHTML = '';
+
+        // 获取搜索和排序参数
+        const searchTerm = (document.getElementById('wb-entry-search')?.value || '').toLowerCase();
+        const sortBy = document.getElementById('wb-entry-sort')?.value || 'order-desc';
+
+        // 筛选条目
+        let entries = this.loadEntries().filter(e => e.bookId === this.currentBookId);
+
+        // 搜索过滤
+        if (searchTerm) {
+            entries = entries.filter(e => {
+                const searchableText = `${e.id} ${e.title} ${e.keys.join(' ')} ${e.tags?.join(' ')}`.toLowerCase();
+                return searchableText.includes(searchTerm);
+            });
         }
-        
-        const editBtn = document.createElement('button');
-        editBtn.className = 'wb-edit-btn';
-        editBtn.textContent = '编辑';
-        editBtn.dataset.ruleId = rule.id;
-        
-        header.appendChild(content);
-        header.appendChild(editBtn);
-        card.appendChild(header);
-    },
-    
-    updatePreview(ruleId) {
-        const pv = document.getElementById(`wb-preview-${ruleId}`);
-        const contentEl = document.getElementById(`wb-content-${ruleId}`);
-        const useVarsEl = document.getElementById(`wb-variables-${ruleId}`);
-        
-        if (pv && contentEl) {
-            const useVars = useVarsEl?.checked;
-            const raw = contentEl.value || '';
-            pv.textContent = useVars ? Utils.replaceVariables(raw) : raw;
+
+        // 排序
+        entries.sort((a, b) => {
+            switch(sortBy) {
+                case 'order-desc': return b.order - a.order;
+                case 'order-asc': return a.order - b.order;
+                case 'title': return (a.title || '').localeCompare(b.title || '');
+                case 'updated': return (b._meta?.updatedAt || 0) - (a._meta?.updatedAt || 0);
+                default: return 0;
+            }
+        });
+
+        // 渲染每个条目
+        entries.forEach(entry => {
+            const tr = document.createElement('tr');
+
+            const statusClass = entry.enabled ? 'wb-tag-active' : 'wb-tag-disabled';
+            const statusText = entry.enabled ? '启用' : '禁用';
+
+            tr.innerHTML = `
+                <td>
+                    <div style="font-weight:500;">${entry.id}</div>
+                    <div style="font-size:12px;color:#666;">${entry.title || '无标题'}</div>
+                </td>
+                <td>${entry.order}</td>
+                <td style="font-size:12px;">${this.getPositionLabel(entry.position)}</td>
+                <td>
+                    <span class="wb-tag wb-tag-${entry.scope}">${this.getScopeLabel(entry.scope)}</span>
+                    <span class="wb-tag ${statusClass}">${statusText}</span>
+                </td>
+                <td style="font-size:12px;">${entry.keys.slice(0, 3).join(', ')}${entry.keys.length > 3 ? '...' : ''}</td>
+                <td>
+                    <div class="wb-entry-actions">
+                        <button onclick="WorldBookScreen.editEntry('${entry.id}')">编辑</button>
+                        <button onclick="WorldBookScreen.duplicateEntry('${entry.id}')">复制</button>
+                        <button onclick="WorldBookScreen.deleteEntry('${entry.id}')">删除</button>
+                    </div>
+                </td>
+            `;
+
+            tbody.appendChild(tr);
+        });
+
+        if (entries.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="6" style="text-align:center;color:#999;">暂无条目</td></tr>';
         }
     },
-    
-  async saveEntry(ruleId) {
-        const state = StateManager.get();
-        const rule = state.worldBook.find(r => r.id === ruleId);
-        if (!rule) return;
 
-        rule.name = document.getElementById(`wb-name-${ruleId}`).value || '未命名';
-        rule.category = document.getElementById(`wb-category-${ruleId}`).value;
-        rule.triggers = document.getElementById(`wb-triggers-${ruleId}`).value
-            .split(',')
-            .map(t => t.trim())
-            .filter(t => t);
-        rule.content = document.getElementById(`wb-content-${ruleId}`).value;
-        rule.enabled = document.getElementById(`wb-enabled-${ruleId}`).checked;
-        rule.constant = document.getElementById(`wb-constant-${ruleId}`).checked;
-        rule.variables = document.getElementById(`wb-variables-${ruleId}`).checked;
-        rule.priority = parseInt(document.getElementById(`wb-priority-${ruleId}`).value) || 100;
-        rule.comment = document.getElementById(`wb-comment-${ruleId}`).value;
+    // 获取位置标签
+    getPositionLabel(position) {
+        const labels = {
+            'after_char_defs': '角色定义后',
+            'before_char_defs': '角色定义前',
+            'an_top': '作者注顶部',
+            'an_bottom': '作者注底部',
+            'depth0_system': '@Depth=0(系统)',
+            'depth0_user': '@Depth=0(用户)',
+            'depth0_assistant': '@Depth=0(助手)'
+        };
+        return labels[position] || position;
+    },
 
-        // 特殊处理离线收益规则的value字段
-        if (rule.id === 'rule001') {
-            const valueInput = document.getElementById(`wb-value-${ruleId}`);
-            if (valueInput) {
-                const newValue = parseInt(valueInput.value) || 1;
-                rule.value = newValue;
-                // 同步更新content中的值
-                if (!rule.content.includes('{{worldBook.rule001.value')) {
-                    rule.content = `AI每分钟获得{{worldBook.rule001.value:${newValue}}}金币的离线收入`;
-                } else {
-                    rule.content = rule.content.replace(
-                        /\{\{worldBook\.rule001\.value:\d+\}\}/g,
-                        `{{worldBook.rule001.value:${newValue}}}`
-                    );
+    // 创建新书
+    createBook() {
+        const name = prompt('请输入世界书名称：');
+        if (!name) return;
+
+        const scope = prompt('请选择作用域 (global/char/event)：', 'global') || 'global';
+        const desc = prompt('请输入描述（可选）：') || '';
+
+        const book = {
+            id: `book.${Date.now()}`,
+            name: name,
+            scope: scope,
+            persona: '',
+            desc: desc,
+            entryCount: 0,
+            createdAt: Date.now(),
+            updatedAt: Date.now()
+        };
+
+        if (scope === 'char') {
+            book.persona = prompt('请输入角色代号（如: fang）：') || '';
+        }
+
+        const books = this.loadBooks();
+        books.push(book);
+        this.saveBooks(books);
+
+        this.renderShelf();
+        alert('世界书创建成功！');
+    },
+
+    // 创建新条目
+    createEntry() {
+        if (!this.currentBookId) return;
+
+        const book = this.loadBooks().find(b => b.id === this.currentBookId);
+        if (!book) return;
+
+        this.editingEntry = {
+            id: '',
+            bookId: this.currentBookId,
+            title: '',
+            scope: book.scope,
+            speaker: book.persona || 'any',
+            keys: [],
+            filters: [],
+            content: '',
+            order: 60,
+            position: 'after_char_defs',
+            strategy: 'trigger',
+            timing: { delay: 0, sticky: 0, cooldown: 0 },
+            recursion: { allow: true, maxSteps: 2 },
+            tags: [],
+            enabled: true,
+            _meta: { createdAt: Date.now(), updatedAt: Date.now() }
+        };
+
+        this.openDrawer();
+    },
+
+    // 编辑条目
+    editEntry(entryId) {
+        const entry = this.loadEntries().find(e => e.id === entryId);
+        if (!entry) return;
+
+        this.editingEntry = { ...entry };
+        this.openDrawer();
+    },
+
+    // 打开编辑抽屉
+    openDrawer() {
+        const drawer = document.getElementById('wb-entry-drawer');
+        if (!drawer) return;
+
+        drawer.classList.add('open');
+
+        // 填充表单
+        const e = this.editingEntry;
+        document.getElementById('wb-entry-id').value = e.id || '';
+        document.getElementById('wb-entry-title').value = e.title || '';
+        document.getElementById('wb-entry-scope').value = e.scope || 'global';
+        document.getElementById('wb-entry-speaker').value = e.speaker || 'any';
+        document.getElementById('wb-entry-keys').value = e.keys?.join(', ') || '';
+        document.getElementById('wb-entry-filters').value = e.filters?.join(', ') || '';
+        document.getElementById('wb-entry-content').value = e.content || '';
+        document.getElementById('wb-entry-order').value = e.order || 60;
+        document.getElementById('wb-entry-position').value = e.position || 'after_char_defs';
+        document.getElementById('wb-entry-strategy').value = e.strategy || 'trigger';
+        document.getElementById('wb-entry-delay').value = e.timing?.delay || 0;
+        document.getElementById('wb-entry-sticky').value = e.timing?.sticky || 0;
+        document.getElementById('wb-entry-cooldown').value = e.timing?.cooldown || 0;
+        document.getElementById('wb-entry-recursion').checked = e.recursion?.allow !== false;
+        document.getElementById('wb-entry-max-steps').value = e.recursion?.maxSteps || 2;
+        document.getElementById('wb-entry-tags').value = e.tags?.join(', ') || '';
+        document.getElementById('wb-entry-enabled').checked = e.enabled !== false;
+    },
+
+    // 关闭编辑抽屉
+    closeDrawer() {
+        const drawer = document.getElementById('wb-entry-drawer');
+        if (drawer) {
+            drawer.classList.remove('open');
+        }
+        this.editingEntry = null;
+    },
+
+    // 保存条目
+    saveEntry() {
+        const id = document.getElementById('wb-entry-id').value.trim();
+        if (!id) {
+            alert('请输入条目ID！');
+            return;
+        }
+
+        const content = document.getElementById('wb-entry-content').value.trim();
+        if (!content) {
+            alert('请输入条目内容！');
+            return;
+        }
+
+        const entry = {
+            id: id,
+            bookId: this.currentBookId,
+            title: document.getElementById('wb-entry-title').value,
+            scope: document.getElementById('wb-entry-scope').value,
+            speaker: document.getElementById('wb-entry-speaker').value,
+            keys: document.getElementById('wb-entry-keys').value
+                .split(',')
+                .map(k => k.trim())
+                .filter(k => k),
+            filters: document.getElementById('wb-entry-filters').value
+                .split(',')
+                .map(f => f.trim())
+                .filter(f => f),
+            content: content,
+            order: parseInt(document.getElementById('wb-entry-order').value) || 60,
+            position: document.getElementById('wb-entry-position').value,
+            strategy: document.getElementById('wb-entry-strategy').value,
+            timing: {
+                delay: parseInt(document.getElementById('wb-entry-delay').value) || 0,
+                sticky: parseInt(document.getElementById('wb-entry-sticky').value) || 0,
+                cooldown: parseInt(document.getElementById('wb-entry-cooldown').value) || 0
+            },
+            recursion: {
+                allow: document.getElementById('wb-entry-recursion').checked,
+                maxSteps: parseInt(document.getElementById('wb-entry-max-steps').value) || 2
+            },
+            tags: document.getElementById('wb-entry-tags').value
+                .split(',')
+                .map(t => t.trim())
+                .filter(t => t),
+            enabled: document.getElementById('wb-entry-enabled').checked,
+            _meta: {
+                createdAt: this.editingEntry?._meta?.createdAt || Date.now(),
+                updatedAt: Date.now()
+            }
+        };
+
+        // 保存条目
+        let entries = this.loadEntries();
+        const existingIndex = entries.findIndex(e => e.id === id);
+
+        if (existingIndex >= 0) {
+            entries[existingIndex] = entry;
+        } else {
+            entries.push(entry);
+        }
+
+        this.saveEntries(entries);
+        this.updateBookCounts();
+        this.closeDrawer();
+        this.renderEntries();
+
+        alert('条目保存成功！');
+    },
+
+    // 删除条目
+    deleteEntry(entryId) {
+        if (!confirm(`确定要删除条目 "${entryId}" 吗？`)) return;
+
+        let entries = this.loadEntries();
+        entries = entries.filter(e => e.id !== entryId);
+        this.saveEntries(entries);
+
+        this.updateBookCounts();
+        this.renderEntries();
+
+        alert('条目已删除！');
+    },
+
+    // 复制条目
+    duplicateEntry(entryId) {
+        const entry = this.loadEntries().find(e => e.id === entryId);
+        if (!entry) return;
+
+        const newEntry = {
+            ...entry,
+            id: `${entry.id}_copy_${Date.now()}`,
+            title: `${entry.title || ''}（副本）`,
+            _meta: {
+                createdAt: Date.now(),
+                updatedAt: Date.now()
+            }
+        };
+
+        const entries = this.loadEntries();
+        entries.push(newEntry);
+        this.saveEntries(entries);
+
+        this.updateBookCounts();
+        this.renderEntries();
+
+        alert('条目复制成功！');
+    },
+
+    // 更新书本条目计数
+    updateBookCounts() {
+        const books = this.loadBooks();
+        const entries = this.loadEntries();
+
+        books.forEach(book => {
+            book.entryCount = entries.filter(e => e.bookId === book.id && e.enabled).length;
+        });
+
+        this.saveBooks(books);
+    },
+
+    // 返回书架
+    backToShelf() {
+        this.currentBookId = null;
+        this.showView('shelf');
+    },
+
+    // 导出功能
+    exportAll() {
+        const data = {
+            books: this.loadBooks(),
+            entries: this.loadEntries(),
+            settings: this.loadSettings(),
+            exportDate: new Date().toISOString()
+        };
+
+        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `worldbook_all_${Date.now()}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+    },
+
+    exportBook() {
+        if (!this.currentBookId) return;
+
+        const book = this.loadBooks().find(b => b.id === this.currentBookId);
+        const entries = this.loadEntries().filter(e => e.bookId === this.currentBookId);
+
+        const data = {
+            book: book,
+            entries: entries,
+            exportDate: new Date().toISOString()
+        };
+
+        const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `worldbook_${book.name}_${Date.now()}.json`;
+        a.click();
+        URL.revokeObjectURL(url);
+    },
+
+    // 导入功能
+    importAll() {
+        const input = document.getElementById('wb-import-file');
+        input.onchange = async (e) => {
+            const file = e.target.files[0];
+            if (!file) return;
+
+            try {
+                const text = await file.text();
+                const data = JSON.parse(text);
+
+                if (data.books) {
+                    this.saveBooks(data.books);
                 }
+                if (data.entries) {
+                    this.saveEntries(data.entries);
+                }
+                if (data.settings) {
+                    this.saveSettings(data.settings);
+                }
+
+                this.updateBookCounts();
+                this.renderShelf();
+                alert('导入成功！');
+            } catch (err) {
+                alert('导入失败：' + err.message);
+            }
+
+            input.value = '';
+        };
+        input.click();
+    },
+
+    importToBook() {
+        if (!this.currentBookId) return;
+
+        const input = document.getElementById('wb-import-file');
+        input.onchange = async (e) => {
+            const file = e.target.files[0];
+            if (!file) return;
+
+            try {
+                const text = await file.text();
+                const data = JSON.parse(text);
+
+                if (data.entries && Array.isArray(data.entries)) {
+                    let entries = this.loadEntries();
+
+                    // 将导入的条目强制设置为当前书本
+                    data.entries.forEach(entry => {
+                        entry.bookId = this.currentBookId;
+
+                        // 检查是否已存在
+                        const existingIndex = entries.findIndex(e => e.id === entry.id);
+                        if (existingIndex >= 0) {
+                            entries[existingIndex] = entry;
+                        } else {
+                            entries.push(entry);
+                        }
+                    });
+
+                    this.saveEntries(entries);
+                    this.updateBookCounts();
+                    this.renderEntries();
+                    alert(`成功导入 ${data.entries.length} 个条目！`);
+                } else {
+                    alert('文件格式错误！');
+                }
+            } catch (err) {
+                alert('导入失败：' + err.message);
+            }
+
+            input.value = '';
+        };
+        input.click();
+    },
+
+    // 渲染激活设置
+    renderSettings() {
+        const settings = this.loadSettings();
+
+        document.getElementById('wb-scan-depth').value = settings.scanDepth;
+        document.getElementById('wb-min-activations').value = settings.minActivations;
+        document.getElementById('wb-max-recursion').value = settings.maxRecursion;
+        document.getElementById('wb-budget-percent').value = settings.budgetPercent;
+        document.getElementById('wb-budget-display').textContent = settings.budgetPercent + '%';
+        document.getElementById('wb-include-names').checked = settings.includeNames;
+        document.getElementById('wb-case-sensitive').checked = settings.caseSensitive;
+        document.getElementById('wb-whole-words').checked = settings.wholeWords;
+        document.getElementById('wb-overflow-alert').checked = settings.overflowAlert;
+
+        // 绑定滑块事件
+        document.getElementById('wb-budget-percent').oninput = (e) => {
+            document.getElementById('wb-budget-display').textContent = e.target.value + '%';
+        };
+    },
+
+    // 保存设置
+    saveSettingsToStorage() {
+        const settings = {
+            scanDepth: parseInt(document.getElementById('wb-scan-depth').value),
+            minActivations: parseInt(document.getElementById('wb-min-activations').value),
+            maxRecursion: parseInt(document.getElementById('wb-max-recursion').value),
+            budgetPercent: parseInt(document.getElementById('wb-budget-percent').value),
+            includeNames: document.getElementById('wb-include-names').checked,
+            caseSensitive: document.getElementById('wb-case-sensitive').checked,
+            wholeWords: document.getElementById('wb-whole-words').checked,
+            overflowAlert: document.getElementById('wb-overflow-alert').checked
+        };
+
+        this.saveSettings(settings);
+        alert('设置已保存！');
+    },
+
+    // 渲染测试沙盒
+    renderSandbox() {
+        // 清空结果区域
+        document.getElementById('wb-injected-list').innerHTML = '';
+        document.getElementById('wb-delayed-list').innerHTML = '';
+        document.getElementById('wb-cooldown-list').innerHTML = '';
+        document.getElementById('wb-truncated-list').innerHTML = '';
+    },
+
+    // 运行测试
+    runTest() {
+        const context = document.getElementById('wb-test-context').value;
+        const input = document.getElementById('wb-test-input').value;
+
+        if (!input) {
+            alert('请输入测试文本！');
+            return;
+        }
+
+        const settings = this.loadSettings();
+        const entries = this.loadEntries().filter(e => e.enabled);
+
+        // 构建扫描文本
+        const scanText = context + '\n' + input;
+
+        // 匹配条目
+        const matched = [];
+        entries.forEach(entry => {
+            let isMatched = false;
+
+            // 策略判断
+            if (entry.strategy === 'always') {
+                isMatched = true;
+            } else if (entry.keys && entry.keys.length > 0) {
+                // 检查触发词
+                for (const key of entry.keys) {
+                    if (this.testKey(key, scanText, settings)) {
+                        isMatched = true;
+                        break;
+                    }
+                }
+            }
+
+            if (isMatched) {
+                matched.push(entry);
+            }
+        });
+
+        // 按优先级排序
+        matched.sort((a, b) => b.order - a.order);
+
+        // 模拟预算限制（简化版）
+        const budget = 1000; // 假设总预算1000 tokens
+        const budgetLimit = Math.floor(budget * settings.budgetPercent / 100);
+        let usedBudget = 0;
+
+        const injected = [];
+        const truncated = [];
+        const delayed = [];
+        const cooldown = [];
+
+        matched.forEach(entry => {
+            // 估算token数（简化：字符数/4）
+            const tokens = Math.ceil(entry.content.length / 4);
+
+            // 时序判断（简化版）
+            if (entry.timing?.cooldown > 0) {
+                cooldown.push(entry);
+            } else if (entry.timing?.delay > 0) {
+                delayed.push(entry);
+            } else if (usedBudget + tokens <= budgetLimit) {
+                injected.push(entry);
+                usedBudget += tokens;
+            } else {
+                truncated.push(entry);
+            }
+        });
+
+        // 显示结果
+        this.renderTestResults('wb-injected-list', injected, '✅');
+        this.renderTestResults('wb-delayed-list', delayed, '⏳');
+        this.renderTestResults('wb-cooldown-list', cooldown, '🧊');
+        this.renderTestResults('wb-truncated-list', truncated, '✂️');
+
+        if (settings.overflowAlert && truncated.length > 0) {
+            alert(`⚠️ 预算溢出警告：有 ${truncated.length} 个条目被裁剪！`);
+        }
+    },
+
+    // 测试关键词
+    testKey(key, text, settings) {
+        // 检查是否是正则表达式
+        if (key.startsWith('/') && key.lastIndexOf('/') > 0) {
+            try {
+                const lastSlash = key.lastIndexOf('/');
+                const pattern = key.substring(1, lastSlash);
+                const flags = key.substring(lastSlash + 1);
+                const regex = new RegExp(pattern, flags);
+                return regex.test(text);
+            } catch (e) {
+                console.error('正则表达式错误:', e);
+                return false;
             }
         }
 
-        delete rule.isNew;
-        await Database.saveWorldState();
-        this.render();
-        alert('保存成功！');
-    },
-    
-    async deleteEntry(ruleId) {
-        if (confirm('确定要删除这个条目吗？')) {
-            const state = StateManager.get();
-            state.worldBook = state.worldBook.filter(r => r.id !== ruleId);
-            await Database.saveWorldState();
-            this.render();
+        // 普通关键词匹配
+        if (!settings.caseSensitive) {
+            key = key.toLowerCase();
+            text = text.toLowerCase();
         }
-    },
-    
-    async cancelEdit(ruleId) {
-        const state = StateManager.get();
-        const rule = state.worldBook.find(r => r.id === ruleId);
-        if (rule && rule.isNew) {
-            state.worldBook = state.worldBook.filter(r => r.id !== ruleId);
-            await Database.saveWorldState();
+
+        if (settings.wholeWords) {
+            const regex = new RegExp(`\\b${key}\\b`);
+            return regex.test(text);
         }
-        this.render();
+
+        return text.includes(key);
+    },
+
+    // 渲染测试结果
+    renderTestResults(containerId, entries, icon) {
+        const container = document.getElementById(containerId);
+        if (!container) return;
+
+        container.innerHTML = '';
+
+        if (entries.length === 0) {
+            container.innerHTML = '<div style="color:#999;font-size:12px;">无</div>';
+            return;
+        }
+
+        entries.forEach(entry => {
+            const div = document.createElement('div');
+            div.className = 'wb-result-item';
+            div.innerHTML = `
+                <div style="display:flex;justify-content:space-between;align-items:center;">
+                    <span>${icon} ${entry.id}</span>
+                    <span style="font-size:11px;color:#666;">优先级: ${entry.order}</span>
+                </div>
+                <div style="font-size:12px;color:#666;margin-top:4px;">
+                    ${entry.title || '无标题'} | ${this.getPositionLabel(entry.position)}
+                </div>
+            `;
+            container.appendChild(div);
+        });
+    },
+
+    // 绑定事件
+    bindEvents() {
+        // 搜索框
+        const searchInput = document.getElementById('wb-entry-search');
+        if (searchInput) {
+            searchInput.addEventListener('input', () => this.renderEntries());
+        }
+
+        // 排序选择
+        const sortSelect = document.getElementById('wb-entry-sort');
+        if (sortSelect) {
+            sortSelect.addEventListener('change', () => this.renderEntries());
+        }
     }
 };
+

--- a/style.css
+++ b/style.css
@@ -328,3 +328,448 @@ body, html { margin: 0; padding: 0; height: 100%; font-family: -apple-system, Bl
         font-size: 14px;
     }
 }
+
+/* ========== 世界书增强样式 ========== */
+
+/* 基础布局 */
+.wb-view {
+    flex-grow: 1;
+    overflow-y: auto;
+    padding: 15px;
+}
+
+.wb-header-actions {
+    display: flex;
+    gap: 10px;
+    margin-left: auto;
+}
+
+.wb-icon-btn {
+    background: none;
+    border: none;
+    font-size: 20px;
+    padding: 5px;
+    cursor: pointer;
+    opacity: 0.7;
+    transition: opacity 0.2s;
+}
+
+.wb-icon-btn:hover {
+    opacity: 1;
+}
+
+/* 工具栏 */
+.wb-toolbar {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 15px;
+    flex-wrap: wrap;
+    align-items: center;
+}
+
+.wb-btn, .wb-btn-primary {
+    padding: 10px 16px;
+    border-radius: 10px;
+    border: none;
+    font-size: 14px;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.wb-btn {
+    background: #f0f0f0;
+    color: #333;
+}
+
+.wb-btn:hover {
+    background: #e0e0e0;
+}
+
+.wb-btn-primary {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+}
+
+.wb-btn-primary:hover {
+    transform: scale(1.02);
+    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+}
+
+/* 书架网格 */
+.wb-books-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 15px;
+}
+
+.wb-book-card {
+    background: white;
+    border-radius: 16px;
+    padding: 20px;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+    display: flex;
+    align-items: center;
+    gap: 15px;
+    cursor: pointer;
+    transition: all 0.3s;
+}
+
+.wb-book-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 4px 16px rgba(0,0,0,0.12);
+}
+
+.wb-book-icon {
+    font-size: 40px;
+    width: 60px;
+    height: 60px;
+    background: linear-gradient(135deg, #667eea20 0%, #764ba220 100%);
+    border-radius: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.wb-book-info {
+    flex: 1;
+}
+
+.wb-book-info h3 {
+    margin: 0 0 5px 0;
+    font-size: 16px;
+    font-weight: 600;
+}
+
+.wb-book-info p {
+    margin: 0;
+    font-size: 13px;
+    color: #666;
+}
+
+.wb-book-meta {
+    font-size: 13px;
+    color: #888;
+    padding: 4px 8px;
+    background: #f5f5f5;
+    border-radius: 6px;
+}
+
+/* 搜索框 */
+.wb-search {
+    flex: 1;
+    padding: 8px 12px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    font-size: 14px;
+}
+
+.wb-select {
+    padding: 8px 12px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    font-size: 14px;
+    background: white;
+}
+
+/* 条目表格 */
+.wb-entries-table {
+    background: white;
+    border-radius: 12px;
+    overflow: hidden;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+}
+
+.wb-entries-table table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.wb-entries-table th {
+    background: #f8f8f8;
+    padding: 12px;
+    text-align: left;
+    font-size: 13px;
+    font-weight: 600;
+    color: #555;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.wb-entries-table td {
+    padding: 12px;
+    font-size: 13px;
+    border-bottom: 1px solid #f0f0f0;
+}
+
+.wb-entries-table tr:hover {
+    background: #fafafa;
+}
+
+.wb-entry-actions {
+    display: flex;
+    gap: 8px;
+}
+
+.wb-entry-actions button {
+    padding: 4px 8px;
+    font-size: 12px;
+    border-radius: 6px;
+    border: 1px solid #ddd;
+    background: white;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.wb-entry-actions button:hover {
+    background: #f0f0f0;
+}
+
+/* 编辑抽屉 */
+.wb-drawer {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    z-index: 1000;
+    display: none;
+}
+
+.wb-drawer.open {
+    display: block;
+}
+
+.wb-drawer-overlay {
+    position: absolute;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    left: 0;
+    background: rgba(0,0,0,0.5);
+}
+
+.wb-drawer-content {
+    position: absolute;
+    right: 0;
+    top: 0;
+    bottom: 0;
+    width: min(500px, 90vw);
+    background: white;
+    box-shadow: -2px 0 16px rgba(0,0,0,0.15);
+    display: flex;
+    flex-direction: column;
+    animation: slideIn 0.3s ease;
+}
+
+@keyframes slideIn {
+    from { transform: translateX(100%); }
+    to { transform: translateX(0); }
+}
+
+.wb-drawer-header {
+    padding: 20px;
+    border-bottom: 1px solid #e0e0e0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.wb-drawer-header h3 {
+    margin: 0;
+    font-size: 18px;
+}
+
+.wb-close-btn {
+    background: none;
+    border: none;
+    font-size: 24px;
+    cursor: pointer;
+    color: #666;
+}
+
+.wb-drawer-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px;
+}
+
+.wb-drawer-footer {
+    padding: 20px;
+    border-top: 1px solid #e0e0e0;
+    display: flex;
+    gap: 10px;
+}
+
+/* 表单组件 */
+.wb-form-group {
+    margin-bottom: 15px;
+}
+
+.wb-form-group label {
+    display: block;
+    font-size: 13px;
+    color: #555;
+    margin-bottom: 5px;
+    font-weight: 500;
+}
+
+.wb-form-group input[type="text"],
+.wb-form-group input[type="number"],
+.wb-form-group textarea,
+.wb-form-group select {
+    width: 100%;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    font-size: 14px;
+    transition: border-color 0.2s;
+}
+
+.wb-form-group input:focus,
+.wb-form-group textarea:focus,
+.wb-form-group select:focus {
+    outline: none;
+    border-color: #667eea;
+}
+
+.wb-form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 15px;
+}
+
+.wb-timing-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 10px;
+}
+
+.wb-timing-row input {
+    width: 100%;
+}
+
+/* 设置页面 */
+.wb-settings-content {
+    max-width: 600px;
+    margin: 0 auto;
+}
+
+.wb-setting-group {
+    background: white;
+    padding: 15px;
+    border-radius: 12px;
+    margin-bottom: 15px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+}
+
+.wb-setting-group label {
+    display: block;
+    font-size: 14px;
+    font-weight: 500;
+    margin-bottom: 8px;
+}
+
+.wb-setting-group input[type="number"],
+.wb-setting-group input[type="range"] {
+    width: 100%;
+    padding: 8px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+}
+
+.wb-setting-group input[type="checkbox"] {
+    margin-right: 8px;
+}
+
+.wb-hint {
+    display: block;
+    font-size: 12px;
+    color: #888;
+    margin-top: 5px;
+}
+
+/* 沙盒测试 */
+.wb-sandbox-content {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+}
+
+.wb-sandbox-input {
+    background: white;
+    padding: 20px;
+    border-radius: 12px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+}
+
+.wb-sandbox-input textarea {
+    width: 100%;
+    min-height: 150px;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 8px;
+    margin-bottom: 15px;
+    resize: vertical;
+}
+
+.wb-sandbox-results {
+    display: flex;
+    flex-direction: column;
+    gap: 15px;
+}
+
+.wb-result-section {
+    background: white;
+    padding: 15px;
+    border-radius: 12px;
+    box-shadow: 0 1px 4px rgba(0,0,0,0.08);
+}
+
+.wb-result-section h4 {
+    margin: 0 0 10px 0;
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.wb-result-item {
+    padding: 8px;
+    background: #f8f8f8;
+    border-radius: 6px;
+    margin-bottom: 8px;
+    font-size: 13px;
+}
+
+.wb-result-item:last-child {
+    margin-bottom: 0;
+}
+
+/* 响应式调整 */
+@media (max-width: 768px) {
+    .wb-books-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .wb-sandbox-content {
+        grid-template-columns: 1fr;
+    }
+
+    .wb-form-row {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* 状态标签 */
+.wb-tag {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 11px;
+    font-weight: 500;
+    margin-right: 4px;
+}
+
+.wb-tag-global { background: #e3f2fd; color: #1976d2; }
+.wb-tag-char { background: #fce4ec; color: #c2185b; }
+.wb-tag-event { background: #f3e5f5; color: #7b1fa2; }
+.wb-tag-active { background: #e8f5e9; color: #388e3c; }
+.wb-tag-disabled { background: #fafafa; color: #9e9e9e; }
+


### PR DESCRIPTION
## Summary
- replace world book screen with multi-book management UI and sandbox, settings, and entry drawer
- add comprehensive styles for new world book components
- implement full-featured world book module with books, entries, import/export, settings, and sandbox
- update main app bindings for world book navigation

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc5e014728832fa6ac9b5d928ddb44