### PR TITLE
Align worldbook priority with SillyTavern and refine UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -504,7 +504,7 @@
                 </select>
             </div>
 
-            <!-- 角色选择区域（仅在选择"绑定角色"时显示） -->
+            <!-- 角色选择区域（仅在选择“绑定角色”时显示，暂未实现多角色，仅预留） -->
             <div id="book-character-selection" class="wb-field" style="display:none;">
                 <label class="wb-label">选择要绑定的角色</label>
                 <div id="book-characters-list" style="max-height: 150px; overflow-y: auto; border: 1px solid #e2e8f0; border-radius: 8px; padding: 8px;">

--- a/js/screens/worldbook.js
+++ b/js/screens/worldbook.js
@@ -1080,6 +1080,17 @@ const WorldBookV2 = {
         document.getElementById('book-name').value = this.currentBook.name;
         document.getElementById('book-description').value = this.currentBook.description || '';
         document.getElementById('book-scope').value = this.currentBook.scope || 'global';
+
+        // 确保角色数组存在（兼容旧数据）
+        if (!Array.isArray(this.currentBook.characters)) {
+            if (this.currentBook.character) {
+                this.currentBook.characters = [this.currentBook.character];
+                delete this.currentBook.character;
+            } else {
+                this.currentBook.characters = [];
+            }
+        }
+
         this.toggleCharacterSelection();
 
         // 加载扫描深度和Token预算

--- a/js/screens/worldbook.js
+++ b/js/screens/worldbook.js
@@ -1080,6 +1080,7 @@ const WorldBookV2 = {
         document.getElementById('book-name').value = this.currentBook.name;
         document.getElementById('book-description').value = this.currentBook.description || '';
         document.getElementById('book-scope').value = this.currentBook.scope || 'global';
+        this.toggleCharacterSelection();
 
         // 加载扫描深度和Token预算
         const scanDepthInput = document.getElementById('book-scan-depth');
@@ -1127,7 +1128,65 @@ const WorldBookV2 = {
             dialog.style.display = 'none';
         }
     },
-    
+
+    // 切换角色选择区域显示
+    toggleCharacterSelection() {
+        const scopeSelect = document.getElementById('book-scope');
+        const charSection = document.getElementById('book-character-selection');
+        if (!scopeSelect || !charSection) return;
+
+        if (scopeSelect.value === 'character') {
+            charSection.style.display = 'block';
+            // TODO: populate book-characters-list when multi-character support is implemented
+        } else {
+            charSection.style.display = 'none';
+        }
+    },
+
+    // 导入世界书
+    importBook() {
+        const input = document.createElement('input');
+        input.type = 'file';
+        input.accept = 'application/json';
+        input.addEventListener('change', (e) => {
+            const file = e.target.files[0];
+            if (!file) return;
+
+            const reader = new FileReader();
+            reader.onload = (event) => {
+                try {
+                    const data = JSON.parse(event.target.result);
+                    if (!data.book || !data.entries) {
+                        alert('文件格式不正确。');
+                        return;
+                    }
+
+                    const bookId = data.book.id || `import_${Date.now()}`;
+                    const newBook = { ...data.book, id: bookId };
+                    const newEntries = (data.entries || []).map(entry => ({
+                        ...entry,
+                        id: entry.id || `import_entry_${Date.now()}_${Math.random().toString(16).slice(2)}`,
+                        bookId
+                    }));
+
+                    this.books.push(newBook);
+                    this.entries.push(...newEntries);
+                    this.currentBook = newBook;
+                    this.saveData();
+                    this.render();
+                    alert('世界书导入成功！');
+                } catch (err) {
+                    console.error(err);
+                    alert('导入世界书失败：' + err.message);
+                }
+            };
+
+            reader.readAsText(file);
+        });
+
+        input.click();
+    },
+
     // 删除世界书
     deleteBook() {
         if (!this.currentBook) return;


### PR DESCRIPTION
## Summary
- Fix worldbook entry sorting to prioritize higher `order` values
- Implement SillyTavern-style token budgeting with constant and triggered entries
- Clarify worldbook UI buttons and simplify book settings dialog
- Add toggle handler for book scope selection and stubbed book import

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run test:e2e` *(fails: sh: 1: playwright: Permission denied)*


------
https://chatgpt.com/codex/tasks/task_e_68bfb6df9c28832f82abf0d97a7bf763